### PR TITLE
[substrate] Add sudo account to genesis flow

### DIFF
--- a/platforms/network-schema.json
+++ b/platforms/network-schema.json
@@ -874,6 +874,7 @@
             "name": { "type": "string","pattern": "^[a-z0-9-_]{1,30}$","description":"Name of the peer"},
             "subject": { "type": "string", "description": "This is the alternative identity of the peer node"},
             "type":{"type":"string","enum":["validator","bootnode","member","ipfs","ipfs-bootnode"],"description":"value can be validator, bootnode or member; ipfs type is for vitalAM only"},
+            "sudo":{"type": "boolean", "description": "Set sudo to true to dedicate the peer as the sudo node, only one peer can be sudo node and the rest have to be set to false"},
             "p2p":  { "$ref":"#/definitions/shared_port_ambassador", "description":"P2P port with external access"},
             "swarm":  { "$ref":"#/definitions/shared_port_ambassador","description":"IPFS Swarm port with external access"},
             "api":  { "$ref":"#/definitions/shared_port","description":"API port"},

--- a/platforms/substrate/charts/substrate-genesis/templates/job.yaml
+++ b/platforms/substrate/charts/substrate-genesis/templates/job.yaml
@@ -51,6 +51,8 @@ spec:
           value: {{ .Values.aura_key }}
         - name: GRANDPA_KEY
           value: {{ .Values.grandpa_key }}
+        - name: SUDO_KEY
+          value: {{ .Values.sudo_key }}
         command: ["bash", "-c"]
         args:
         - |-
@@ -111,6 +113,9 @@ spec:
           echo {{.}}
           GENESIS=$(echo "$GENESIS" | jq --arg grandpa {{.}} '.genesis.runtime.palletGrandpa.authorities += [[$grandpa, 1]]')
           {{- end }}
+
+          echo "Inserting sudo key into genesis"
+          GENESIS=$(echo "$GENESIS" | jq --arg sudokey ${SUDO_KEY} '.genesis.runtime.palletSudo.key |= $sudokey')
 
           echo "$GENESIS" > genesis.json
 

--- a/platforms/substrate/charts/substrate-genesis/values.yaml
+++ b/platforms/substrate/charts/substrate-genesis/values.yaml
@@ -67,3 +67,7 @@ grandpa_keys:
   # e.g.
   # -5FPQ5bk3kiwpIEH72sayKBJe7Q57xNwAwmes3FA2YW37AE41
   # -5FPQ5bk3i1wadHJWEHUAIBJe7Q57xNwAwmes3FA2YW37AE41
+sudo_key:
+  # Provide the key of the dedicated sudo peer
+  # e.g.
+  # -5FPQ5bk3kiwpIEH72sayKBJe7Q57xNwAwmes3FA2YW37AE41

--- a/platforms/substrate/configuration/roles/create/genesis/tasks/create_genesis_job.yaml
+++ b/platforms/substrate/configuration/roles/create/genesis/tasks/create_genesis_job.yaml
@@ -14,6 +14,7 @@
     component_name: "{{ org.name }}-genesis-job"
     aura_keys: "{{ aura_key_list }}"
     grandpa_keys: "{{ grandpa_key_list }}"
+    sudo_key: "{{ sudo_key_list }}"
   tags: 
     - molecule-idempotence-notest
 

--- a/platforms/substrate/configuration/roles/create/genesis/tasks/main.yaml
+++ b/platforms/substrate/configuration/roles/create/genesis/tasks/main.yaml
@@ -13,6 +13,10 @@
   set_fact:
     grandpa_key_list: []
 
+- name: Set sudo_key var
+  set_fact:
+    sudo_key_list: 
+
 - name: Pull keys for each validator peer
   include_tasks: nested_main.yaml
   vars:

--- a/platforms/substrate/configuration/roles/create/genesis/tasks/nested_keys.yaml
+++ b/platforms/substrate/configuration/roles/create/genesis/tasks/nested_keys.yaml
@@ -31,3 +31,18 @@
 - name: Set aura key
   set_fact:
     aura_key_list={{ aura_key_list|default([]) + [ aura_key.stdout ] }}
+
+# This task fetches the aura key of the sudo peer and registers it as sudo var
+- name: Get sudo key
+  environment:
+    VAULT_ADDR: "{{ vault.url }}"
+    VAULT_TOKEN: "{{ vault.root_token }}"
+  shell: |
+    vault kv get -field=aura_addr {{ vault.secret_path | default('secretsv2') }}/{{ component_ns }}/{{ peer.name }}/substrate
+  register: sudo
+  when: peer.sudo == true
+
+- name: Insert retrieved key into sudo_key_list var
+  set_fact:
+    sudo_key_list={{ sudo.stdout }}
+  when: peer.sudo == true

--- a/platforms/substrate/configuration/roles/create/helm_component/templates/genesis_job.tpl
+++ b/platforms/substrate/configuration/roles/create/helm_component/templates/genesis_job.tpl
@@ -29,3 +29,4 @@ spec:
       certsecretprefix: {{ vault.secret_path | default('secretsv2') }}/{{ component_ns }}
     aura_keys: {{ aura_key_list }}
     grandpa_keys: {{ grandpa_key_list }}
+    sudo_key: {{ sudo_key_list }}

--- a/platforms/substrate/configuration/samples/network-sample.yaml
+++ b/platforms/substrate/configuration/samples/network-sample.yaml
@@ -104,6 +104,7 @@ network:
           name: validator1
           subject: "O=Validator1,OU=Validator1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: true      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15012       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -115,6 +116,7 @@ network:
           name: validator2
           subject: "O=Validator1,OU=Validator1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15013       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -184,6 +186,7 @@ network:
           name: validator3
           subject: "O=Validator3,OU=Validator3,L=47.38/8.54/Zurich,C=CH" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15021       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -195,6 +198,7 @@ network:
           name: validator4
           subject: "O=Validator4,OU=Validator4,L=47.38/8.54/Zurich,C=CH" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15022       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/substrate/configuration/samples/network-substrate.yaml
+++ b/platforms/substrate/configuration/samples/network-substrate.yaml
@@ -103,6 +103,7 @@ network:
           name: validator1
           subject: "O=Validator1,OU=Validator1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: true      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15012       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -114,6 +115,7 @@ network:
           name: validator2
           subject: "O=Validator1,OU=Validator1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15013       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -192,6 +194,7 @@ network:
           name: validator3
           subject: "O=Validator3,OU=Validator3,L=47.38/8.54/Zurich,C=CH" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15021       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -203,6 +206,7 @@ network:
           name: validator4
           subject: "O=Validator4,OU=Validator4,L=47.38/8.54/Zurich,C=CH" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15022       #Port exposed on ambassador service (use one port per org if using single cluster)

--- a/platforms/substrate/configuration/samples/network-vitalam.yaml
+++ b/platforms/substrate/configuration/samples/network-vitalam.yaml
@@ -101,6 +101,7 @@ network:
           name: validator1
           subject: "O=Validator1,OU=Validator1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: true      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15011       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -112,6 +113,7 @@ network:
           name: validator2
           subject: "O=Validator1,OU=Validator1,L=51.50/-0.13/London,C=GB" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15012       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -188,6 +190,7 @@ network:
           name: validator3
           subject: "O=Validator3,OU=Validator3,L=47.38/8.54/Zurich,C=CH" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15021       #Port exposed on ambassador service (use one port per org if using single cluster)
@@ -199,6 +202,7 @@ network:
           name: validator4
           subject: "O=Validator4,OU=Validator4,L=47.38/8.54/Zurich,C=CH" # This is the node subject. L=lat/long is mandatory for supplychain sample app
           type: validator         # value can be validator or bootnode ( or ipfs, for vitalAM)
+          sudo: false      # value has to be set to true to enable the selected peer to become the sudo node of the network - note only one peer can be sudo == true, the rest will HAVE to be sudo == false 
           p2p:
             port: 30333
             ambassador: 15022       #Port exposed on ambassador service (use one port per org if using single cluster)


### PR DESCRIPTION
Signed-off-by: TonyRowntree <33454202+TonyRowntree@users.noreply.github.com>

**Changelog**
- Added the sudo account flow to the genesis meaning the sudo == true peer defined in the network.yaml will have its key passed as the sudoKey in the genesis file

 

**Reviewed by**

 

**Linked issue**
#INFRA-52
