### PR TITLE
[substrate] sync id-service and inteli-api helm releases

### DIFF
--- a/platforms/substrate/releases/dev/oem/oem/oem-id-service-postgresql.yaml
+++ b/platforms/substrate/releases/dev/oem/oem/oem-id-service-postgresql.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oem-id-service-postgresql
+  namespace: oem-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/postgresql
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: oem-id-service-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres123
+          database: inteli
+        service:
+          ports:
+            postgresql: 5432

--- a/platforms/substrate/releases/dev/oem/oem/oem-id-service.yaml
+++ b/platforms/substrate/releases/dev/oem/oem/oem-id-service.yaml
@@ -1,0 +1,65 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oem-id-service
+  namespace: oem-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/dscp-identity-service
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: oem-id-service
+  values:
+    fullNameOverride: oem-id-service
+    config:
+      externalNodeHost: oem
+      externalPostgresql: oem-id-service-postgresql.oem-subs
+      port: 3001
+      logLevel: info
+      dbName: inteli
+      dbPort: 5432
+      enableLivenessProbe: true
+      selfAddress: 
+      auth:
+        type: NONE
+        jwksUri: https://inteli-poc.eu.auth0.com/.well-known/jwks.json
+        audience: https://inteli-poc.com/api
+        issuer: https://inteli-poc.eu.auth0.com/
+        tokenUrl: https://inteli-poc.eu.auth0.com/oauth/token
+    ingress:
+      enabled: false
+      # annotations: {}
+      # className
+      paths:
+        - /v1/members
+    replicaCount: 1
+    image:
+      repository: ghcr.io/digicatapult/dscp-identity-service
+      pullPolicy: IfNotPresent
+      tag: 'v1.4.0'
+      pullSecrets: ['ghcr-digicatapult']
+
+    postgresql:
+      enabled: false
+      postgresqlDatabase: inteli
+      postgresqlUsername: postgres
+      postgresqlPassword: postgres123
+    dscpNode:
+      enabled: false
+
+    vault:
+      alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+      address: http://vault.internal.dev.intelipoc.com:20002
+      secretprefix: secretsv2/data/oem-subs/oem
+      serviceaccountname: vault-auth
+      role: vault-role
+      authpath: substrateoem
+
+    proxy:
+      provider: ambassador
+      name: oem 
+      external_url_suffix: vitalam.intelipoc.com
+      port: 443
+      issuedFor: oem

--- a/platforms/substrate/releases/dev/oem/oem/oem-inteli-api-postgresql.yaml
+++ b/platforms/substrate/releases/dev/oem/oem/oem-inteli-api-postgresql.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oem-inteli-api-postgresql
+  namespace: oem-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/postgresql
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: oem-inteli-api-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres123
+          database: inteli
+        service:
+          ports:
+            postgresql: 5432

--- a/platforms/substrate/releases/dev/oem/oem/oem-inteli-api.yaml
+++ b/platforms/substrate/releases/dev/oem/oem/oem-inteli-api.yaml
@@ -1,0 +1,73 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oem-inteli-api
+  namespace: oem-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/inteli-api
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: oem-inteli-api
+  values:
+    fullnameOverride: oem-inteli-api
+    config:
+      port: 3000
+      externalPostgresql: oem-inteli-api-postgresql.oem-subs
+      dbName: inteli
+      dbPort: 5432
+      dscpApiHost: oem-api.oem-subs
+      dscpApiPort: 80
+      logLevel: info
+      identityServiceHost: oem-id-service.oem-subs
+      identityServicePort: 3001
+      auth:
+        type: NONE
+        jwksUri: https://inteli-poc.eu.auth0.com/.well-known/jwks.json
+        audience: https://inteli-poc.com/api
+        issuer: https://inteli-poc.eu.auth0.com/
+        tokenUrl: https://inteli-poc.eu.auth0.com/oauth/token
+
+    deployment:
+      annotations: {}
+      livenessProbe:
+        enabled: true
+      replicaCount: 1
+
+    ingress:
+      enabled: false
+      annotations: {}
+      # className: ""
+      paths:
+        - /v1/attachment
+        - /v1/build
+        - /v1/order
+        - /v1/part
+        - /v1/recipe
+
+    service:
+      annotations: {}
+      enabled: false
+      port: 
+
+    image:
+      repository: ghcr.io/digicatapult/inteli-api
+      pullPolicy: IfNotPresent
+      tag: 'v1.28.0'
+      pullSecrets: ['ghcr-digicatapult']
+
+    postgresql:
+      enabled: false
+      postgresqlDatabase: inteli
+      postgresqlUsername: postgres
+      postgresqlPassword: postgres123
+
+
+    proxy:
+      provider: ambassador
+      name: oem 
+      external_url_suffix: vitalam.intelipoc.com
+      port: 443
+      issuedFor: oem

--- a/platforms/substrate/releases/dev/tierone/tierone/tierone-id-service-postgresql.yaml
+++ b/platforms/substrate/releases/dev/tierone/tierone/tierone-id-service-postgresql.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tierone-id-service-postgresql
+  namespace: tierone-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/postgresql
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tierone-id-service-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres123
+          database: inteli
+        service:
+          ports:
+            postgresql: 5432

--- a/platforms/substrate/releases/dev/tierone/tierone/tierone-id-service.yaml
+++ b/platforms/substrate/releases/dev/tierone/tierone/tierone-id-service.yaml
@@ -1,0 +1,65 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tierone-id-service
+  namespace: tierone-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/dscp-identity-service
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tierone-id-service
+  values:
+    fullNameOverride: tierone-id-service
+    config:
+      externalNodeHost: tierone
+      externalPostgresql: tierone-id-service-postgresql.tierone-subs
+      port: 3001
+      logLevel: info
+      dbName: inteli
+      dbPort: 5432
+      enableLivenessProbe: true
+      selfAddress: 
+      auth:
+        type: NONE
+        jwksUri: https://inteli-poc.eu.auth0.com/.well-known/jwks.json
+        audience: https://inteli-poc.com/api
+        issuer: https://inteli-poc.eu.auth0.com/
+        tokenUrl: https://inteli-poc.eu.auth0.com/oauth/token
+    ingress:
+      enabled: false
+      # annotations: {}
+      # className
+      paths:
+        - /v1/members
+    replicaCount: 1
+    image:
+      repository: ghcr.io/digicatapult/dscp-identity-service
+      pullPolicy: IfNotPresent
+      tag: 'v1.4.0'
+      pullSecrets: ['ghcr-digicatapult']
+
+    postgresql:
+      enabled: false
+      postgresqlDatabase: inteli
+      postgresqlUsername: postgres
+      postgresqlPassword: postgres123
+    dscpNode:
+      enabled: false
+
+    vault:
+      alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+      address: http://vault.internal.dev.intelipoc.com:20002
+      secretprefix: secretsv2/data/tierone-subs/tierone
+      serviceaccountname: vault-auth
+      role: vault-role
+      authpath: substratetierone
+
+    proxy:
+      provider: ambassador
+      name: tierone 
+      external_url_suffix: vitalam.intelipoc.com
+      port: 443
+      issuedFor: tierone

--- a/platforms/substrate/releases/dev/tierone/tierone/tierone-inteli-api-postgresql.yaml
+++ b/platforms/substrate/releases/dev/tierone/tierone/tierone-inteli-api-postgresql.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tierone-inteli-api-postgresql
+  namespace: tierone-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/postgresql
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tierone-inteli-api-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres123
+          database: inteli
+        service:
+          ports:
+            postgresql: 5432

--- a/platforms/substrate/releases/dev/tierone/tierone/tierone-inteli-api.yaml
+++ b/platforms/substrate/releases/dev/tierone/tierone/tierone-inteli-api.yaml
@@ -1,0 +1,73 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tierone-inteli-api
+  namespace: tierone-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/inteli-api
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tierone-inteli-api
+  values:
+    fullnameOverride: tierone-inteli-api
+    config:
+      port: 3000
+      externalPostgresql: tierone-inteli-api-postgresql.tierone-subs
+      dbName: inteli
+      dbPort: 5432
+      dscpApiHost: tierone-api.tierone-subs
+      dscpApiPort: 80
+      logLevel: info
+      identityServiceHost: tierone-id-service.tierone-subs
+      identityServicePort: 3001
+      auth:
+        type: NONE
+        jwksUri: https://inteli-poc.eu.auth0.com/.well-known/jwks.json
+        audience: https://inteli-poc.com/api
+        issuer: https://inteli-poc.eu.auth0.com/
+        tokenUrl: https://inteli-poc.eu.auth0.com/oauth/token
+
+    deployment:
+      annotations: {}
+      livenessProbe:
+        enabled: true
+      replicaCount: 1
+
+    ingress:
+      enabled: false
+      annotations: {}
+      # className: ""
+      paths:
+        - /v1/attachment
+        - /v1/build
+        - /v1/order
+        - /v1/part
+        - /v1/recipe
+
+    service:
+      annotations: {}
+      enabled: false
+      port: 
+
+    image:
+      repository: ghcr.io/digicatapult/inteli-api
+      pullPolicy: IfNotPresent
+      tag: 'v1.28.0'
+      pullSecrets: ['ghcr-digicatapult']
+
+    postgresql:
+      enabled: false
+      postgresqlDatabase: inteli
+      postgresqlUsername: postgres
+      postgresqlPassword: postgres123
+
+
+    proxy:
+      provider: ambassador
+      name: tierone 
+      external_url_suffix: vitalam.intelipoc.com
+      port: 443
+      issuedFor: tierone

--- a/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-id-service-postgresql.yaml
+++ b/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-id-service-postgresql.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tiertwo-id-service-postgresql
+  namespace: tiertwo-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/postgresql
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tiertwo-id-service-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres123
+          database: inteli
+        service:
+          ports:
+            postgresql: 5432

--- a/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-id-service.yaml
+++ b/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-id-service.yaml
@@ -1,0 +1,65 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tiertwo-id-service
+  namespace: tiertwo-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/dscp-identity-service
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tiertwo-id-service
+  values:
+    fullNameOverride: tiertwo-id-service
+    config:
+      externalNodeHost: tiertwo
+      externalPostgresql: tiertwo-id-service-postgresql.tiertwo-subs
+      port: 3001
+      logLevel: info
+      dbName: inteli
+      dbPort: 5432
+      enableLivenessProbe: true
+      selfAddress: 
+      auth:
+        type: NONE
+        jwksUri: https://inteli-poc.eu.auth0.com/.well-known/jwks.json
+        audience: https://inteli-poc.com/api
+        issuer: https://inteli-poc.eu.auth0.com/
+        tokenUrl: https://inteli-poc.eu.auth0.com/oauth/token
+    ingress:
+      enabled: false
+      # annotations: {}
+      # className
+      paths:
+        - /v1/members
+    replicaCount: 1
+    image:
+      repository: ghcr.io/digicatapult/dscp-identity-service
+      pullPolicy: IfNotPresent
+      tag: 'v1.4.0'
+      pullSecrets: ['ghcr-digicatapult']
+
+    postgresql:
+      enabled: false
+      postgresqlDatabase: inteli
+      postgresqlUsername: postgres
+      postgresqlPassword: postgres123
+    dscpNode:
+      enabled: false
+
+    vault:
+      alpineutils: ghcr.io/hyperledger/alpine-utils:1.0
+      address: http://vault.internal.dev.intelipoc.com:20002
+      secretprefix: secretsv2/data/tiertwo-subs/tiertwo
+      serviceaccountname: vault-auth
+      role: vault-role
+      authpath: substratetiertwo
+
+    proxy:
+      provider: ambassador
+      name: tiertwo 
+      external_url_suffix: vitalam.intelipoc.com
+      port: 443
+      issuedFor: tiertwo

--- a/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-inteli-api-postgresql.yaml
+++ b/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-inteli-api-postgresql.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tiertwo-inteli-api-postgresql
+  namespace: tiertwo-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/postgresql
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tiertwo-inteli-api-postgresql
+  values:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres123
+          database: inteli
+        service:
+          ports:
+            postgresql: 5432

--- a/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-inteli-api.yaml
+++ b/platforms/substrate/releases/dev/tiertwo/tiertwo/tiertwo-inteli-api.yaml
@@ -1,0 +1,73 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tiertwo-inteli-api
+  namespace: tiertwo-subs
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: examples/dscp-app/charts/inteli-api
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tiertwo-inteli-api
+  values:
+    fullnameOverride: tiertwo-inteli-api
+    config:
+      port: 3000
+      externalPostgresql: tiertwo-inteli-api-postgresql.tiertwo-subs
+      dbName: inteli
+      dbPort: 5432
+      dscpApiHost: tiertwo-api.tiertwo-subs
+      dscpApiPort: 80
+      logLevel: info
+      identityServiceHost: tiertwo-id-service.tiertwo-subs
+      identityServicePort: 3001
+      auth:
+        type: NONE
+        jwksUri: https://inteli-poc.eu.auth0.com/.well-known/jwks.json
+        audience: https://inteli-poc.com/api
+        issuer: https://inteli-poc.eu.auth0.com/
+        tokenUrl: https://inteli-poc.eu.auth0.com/oauth/token
+
+    deployment:
+      annotations: {}
+      livenessProbe:
+        enabled: true
+      replicaCount: 1
+
+    ingress:
+      enabled: false
+      annotations: {}
+      # className: ""
+      paths:
+        - /v1/attachment
+        - /v1/build
+        - /v1/order
+        - /v1/part
+        - /v1/recipe
+
+    service:
+      annotations: {}
+      enabled: false
+      port: 
+
+    image:
+      repository: ghcr.io/digicatapult/inteli-api
+      pullPolicy: IfNotPresent
+      tag: 'v1.28.0'
+      pullSecrets: ['ghcr-digicatapult']
+
+    postgresql:
+      enabled: false
+      postgresqlDatabase: inteli
+      postgresqlUsername: postgres
+      postgresqlPassword: postgres123
+
+
+    proxy:
+      provider: ambassador
+      name: tiertwo 
+      external_url_suffix: vitalam.intelipoc.com
+      port: 443
+      issuedFor: tiertwo


### PR DESCRIPTION
Signed-off-by: TonyRowntree <33454202+TonyRowntree@users.noreply.github.com>

**Changelog**
- Added releases for the dscp-id-service, inteli-api and postgres attachment for both.


 

**Linked issue**
#INFRA-137
