### PR TITLE
[substrate] remove pullSecret from charts

### DIFF
--- a/examples/dscp-app/charts/inteli-api/values.yaml
+++ b/examples/dscp-app/charts/inteli-api/values.yaml
@@ -42,7 +42,7 @@ image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
   tag: 'v1.28.0'
-  pullSecrets: ['ghcr-digicatapult']
+  pullSecrets: 
 
 postgresql:
   enabled: false

--- a/examples/dscp-app/configuration/roles/helm_component/templates/dscp-id-service.tpl
+++ b/examples/dscp-app/configuration/roles/helm_component/templates/dscp-id-service.tpl
@@ -39,7 +39,7 @@ spec:
       repository: ghcr.io/digicatapult/dscp-identity-service
       pullPolicy: IfNotPresent
       tag: 'v1.4.0'
-      pullSecrets: ['ghcr-digicatapult']
+      pullSecrets: 
 
     postgresql:
       enabled: false

--- a/examples/dscp-app/configuration/roles/helm_component/templates/inteli-api.tpl
+++ b/examples/dscp-app/configuration/roles/helm_component/templates/inteli-api.tpl
@@ -56,7 +56,7 @@ spec:
       repository: ghcr.io/digicatapult/inteli-api
       pullPolicy: IfNotPresent
       tag: 'v1.28.0'
-      pullSecrets: ['ghcr-digicatapult']
+      pullSecrets: 
 
     postgresql:
       enabled: false


### PR DESCRIPTION
Signed-off-by: TonyRowntree <33454202+TonyRowntree@users.noreply.github.com>

**Changelog**
- Removed pullSecret key from charts

tested on uat-network

 
 

**Linked issue**
#INFRA-139
