### PR TITLE
[substrate] create chain-watcher helm chart, template and ansible roles

### DIFF
--- a/examples/dscp-app/charts/dscp-chain-watcher/Chart.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/Chart.yaml
@@ -4,11 +4,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
 
-helm_templates:
-  dscp-api: dscp-api.tpl
-  dscp-frontend: dscp-frontend.tpl
-  certissuer: certissuer.tpl
-  postgresql: postgresql.tpl
-  dscp-id-service: dscp-id-service.tpl
-  inteli-api: inteli-api.tpl
-  dscp-chain-watcher: dscp-chain-watcher.tpl
+apiVersion: v2
+name: dscp-chain-watcher
+appVersion: '1.0.0'
+description: A Helm chart for dscp-chain-watcher
+version: '1.0.0'
+type: job

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/_helpers.tpl
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Create name to be used with deployment.
+*/}}
+{{- define "chain-watcher.fullname" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- $name := default .Chart.Name .Values.nameOverride -}}
+      {{- if contains $name .Release.Name -}}
+        {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+      {{- else -}}
+        {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+      {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/configmap.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/configmap.yaml
@@ -1,0 +1,16 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chain-watcher.fullname" . }}-config
+data:
+  dscpApiHost: {{ .Values.config.dscpApiHost }}
+  dscpApiPort: {{ .Values.config.dscpApiPort | quote }}
+  dbHost: {{ .Values.config.dbHost }}
+  dbPort: {{ .Values.config.dbPort | quote }}
+  dbName: {{ .Values.config.dbName }}

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/cronjob.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/cronjob.yaml
@@ -1,0 +1,65 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "chain-watcher.fullname" . }}-cron-job
+  labels:
+    app.kubernetes.io/name: {{ include "chain-watcher.fullname" . }}-cron-job
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 6
+      template:
+        metadata:
+          labels:
+            app: {{ include "chain-watcher.fullname" . }}-cron-job
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 1000
+          containers:
+          - name: {{ include "chain-watcher.fullname" . }}-cron-job
+            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+            imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+            env:
+              - name: DB_HOST
+                valueFrom:
+                  configMapKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-config
+                    key: dbHost
+              - name: DB_PORT
+                valueFrom:
+                  configMapKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-config
+                    key: dbPort
+              - name: DB_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-config
+                    key: dbName
+              - name: DSCP_API_HOST
+                valueFrom:
+                  configMapKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-config
+                    key: dscpApiHost
+              - name: DSCP_API_PORT
+                valueFrom:
+                  configMapKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-config
+                    key: dscpApiPort
+              - name: DB_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-secret
+                    key: dbUsername
+              - name: DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-secret
+                    key: dbPassword

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/db-migration-job.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/db-migration-job.yaml
@@ -1,0 +1,55 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "chain-watcher.fullname" . }}-db-migration
+  labels:
+    app.kubernetes.io/name: {{ include "chain-watcher.fullname" . }}-db-migration
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app: {{ include "chain-watcher.fullname" . }}
+        app.kubernetes.io/name: {{ include "chain-watcher.fullname" . }}-db-migration
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: {{ include "chain-watcher.fullname" . }}-db-migration
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command: [ 'npx', 'knex', "migrate:latest"]
+          env:
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chain-watcher.fullname" . }}-config
+                  key: dbHost
+            - name: DB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chain-watcher.fullname" . }}-config
+                  key: dbPort
+            - name: DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chain-watcher.fullname" . }}-config
+                  key: dbName
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chain-watcher.fullname" . }}-secret
+                  key: dbUsername
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chain-watcher.fullname" . }}-secret
+                  key: dbPassword

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/secret.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/secret.yaml
@@ -4,11 +4,10 @@
 #  SPDX-License-Identifier: Apache-2.0
 ##############################################################################################
 
-helm_templates:
-  dscp-api: dscp-api.tpl
-  dscp-frontend: dscp-frontend.tpl
-  certissuer: certissuer.tpl
-  postgresql: postgresql.tpl
-  dscp-id-service: dscp-id-service.tpl
-  inteli-api: inteli-api.tpl
-  dscp-chain-watcher: dscp-chain-watcher.tpl
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chain-watcher.fullname" . }}-secret
+data:
+  dbUsername: {{ .Values.config.dbUsername | b64enc | quote }}
+  dbPassword: {{ .Values.config.dbPassword | b64enc | quote }}

--- a/examples/dscp-app/charts/dscp-chain-watcher/values.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/values.yaml
@@ -1,0 +1,16 @@
+fullnameOverride:
+
+config:
+  dbHost:
+  dbPort:
+  dbUsername: 
+  dbPassword: 
+  dbName: 
+  dscpApiHost:
+  dscpApiPort: 
+
+image:
+  repository: ghcr.io/inteli-poc/dscp-chain-watcher
+  pullPolicy: IfNotPresent
+  tag: 'v1.0.2'
+  pullSecrets: 

--- a/examples/dscp-app/configuration/deploy-dscp-app.yaml
+++ b/examples/dscp-app/configuration/deploy-dscp-app.yaml
@@ -110,6 +110,19 @@
     when: 
       - network.type == 'substrate'
 
+  - name: "Creating values file for dscp-chain-watcher"
+    include_role:
+      name: "create/dscp/chain-watcher"
+    vars:
+      component_ns: "{{ org.name | lower }}-subs"
+      component_gitops: "{{ org.gitops }}"
+      values_dir: "{{ playbook_dir }}/../../../{{ org.gitops.release_dir }}/{{ org.name | lower }}"
+    loop: "{{ network['organizations'] }}"
+    loop_control:
+      loop_var: org
+    when: 
+      - network.type == 'substrate'
+
   - name: "Get the identities for each VitalAM role"
     include_role:
       name: "setup/identities"

--- a/examples/dscp-app/configuration/roles/create/dscp/chain-watcher/tasks/main.yaml
+++ b/examples/dscp-app/configuration/roles/create/dscp/chain-watcher/tasks/main.yaml
@@ -1,0 +1,30 @@
+##############################################################################################
+#  Copyright Accenture. All Rights Reserved.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##############################################################################################
+# Create chain-watcher values file for the peer nodes
+- name: "Create chain-watcher values file for all peers"
+  include_role:
+    name: helm_component
+  vars:
+    type: "dscp-chain-watcher"
+    component_name: "{{ peer.name }}-chain-watcher"
+    name: "{{ peer.name }}"
+    charts_dir: "examples/dscp-app/charts"
+    dscp_api_addr: "{{ peer.name }}-api"
+    db_host_addr: "{{ peer.name }}-postgresql"
+  loop: "{{ org.services.peers }}"
+  loop_control:
+    loop_var: peer
+  when: (peer.postgresql is defined) and (peer.inteli_api is defined)
+
+# Push the chain-watcher deployment files to repository
+- name: "Push the created deployment files to repository"
+  include_role: 
+    name: "{{ playbook_dir }}/../../../platforms/shared/configuration/roles/git_push"
+  vars:
+    GIT_DIR: "{{ playbook_dir }}/../../../"
+    gitops: "{{ component_gitops }}"
+    GIT_RESET_PATH: "platforms/substrate/configuration"
+    msg: "[ci skip] Pushing deployment files for chain-watcher"

--- a/examples/dscp-app/configuration/roles/helm_component/templates/dscp-chain-watcher.tpl
+++ b/examples/dscp-app/configuration/roles/helm_component/templates/dscp-chain-watcher.tpl
@@ -1,0 +1,29 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: {{ name }}-chain-watcher
+  namespace: {{ component_ns }}
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  chart:
+    path: {{ charts_dir }}/dscp-chain-watcher
+    git: "{{ component_gitops.git_url }}"
+    ref: "{{ component_gitops.branch }}"
+  releaseName: {{ name }}-chain-watcher
+  values:
+    fullnameOverride: {{ name }}-chain-watcher
+    config:
+      dbHost: {{ db_host_addr }}.{{ component_ns }}
+      dbPort: {{ peer.postgresql.port }}
+      dbUsername: {{ peer.postgresql.user }}
+      dbPassword: {{ peer.postgresql.password }}
+      dbName: {{ peer.inteli_api.db_name }}
+      dscpApiHost: {{ dscp_api_addr }}.{{ component_ns }}
+      dscpApiPort: {{ peer.api.port }}
+      
+    image:
+      repository: ghcr.io/inteli-poc/dscp-chain-watcher
+      pullPolicy: IfNotPresent
+      tag: 'v1.0.2'
+      pullSecrets: 

--- a/examples/dscp-app/configuration/roles/helm_lint/vars/main.yaml
+++ b/examples/dscp-app/configuration/roles/helm_lint/vars/main.yaml
@@ -11,3 +11,4 @@ charts:
   postgresql: postgresql
   dscp-id-service: dscp-identity-service
   inteli-api: inteli-api
+  dscp-chain-watcher: dscp-chain-watcher


### PR DESCRIPTION
Signed-off-by: TonyRowntree <33454202+TonyRowntree@users.noreply.github.com>

**Changelog**
- Added chain-watcher full automated deployment. Created helm charts, template and ansible roles.
- Deployed chain-watcher to UAT network.


 

**Linked issue**
#INFRA-152 #INFRA-153 #INFRA-154
