### PR TITLE
sync chain watcher from uat to dev network

### DIFF
--- a/platforms/substrate/releases/dev/oem/oem/oem-chain-watcher.yaml
+++ b/platforms/substrate/releases/dev/oem/oem/oem-chain-watcher.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oem-chain-watcher
+  namespace: oem-subs
+  annotations:
+    fluxcd.io/automated: "true"
+    repository.fluxcd.io/app: image.repository
+    tag.fluxcd.io/app: image.tag
+    filter.fluxcd.io/app: 'glob:v1.0.*'
+spec:
+  chart:
+    path: examples/dscp-app/charts/dscp-chain-watcher
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: oem-chain-watcher
+  values:
+    fullnameOverride: oem-chain-watcher
+    config:
+      dbHost: oem-postgresql.oem-subs
+      dbPort: 5432
+      dbUsername: postgres
+      dbPassword: postgres123
+      dbName: inteli-api
+      dscpApiHost: oem-api.oem-subs
+      dscpApiPort: 80
+
+    image:
+      repository: ghcr.io/inteli-poc/dscp-chain-watcher
+      pullPolicy: IfNotPresent
+      tag: 'v1.0.4750d84'
+      pullSecrets:

--- a/platforms/substrate/releases/dev/tierone/tierone/tierone-chain-watcher.yaml
+++ b/platforms/substrate/releases/dev/tierone/tierone/tierone-chain-watcher.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: tierone-chain-watcher
+  namespace: tierone-subs
+  annotations:
+    fluxcd.io/automated: "true"
+    repository.fluxcd.io/app: image.repository
+    tag.fluxcd.io/app: image.tag
+    filter.fluxcd.io/app: 'glob:v1.0.*'
+spec:
+  chart:
+    path: examples/dscp-app/charts/dscp-chain-watcher
+    git: "https://github.com/inteli-poc/bevel.git"
+    ref: "vitalam"
+  releaseName: tierone-chain-watcher
+  values:
+    fullnameOverride: tierone-chain-watcher
+    config:
+      dbHost: tierone-postgresql.tierone-subs
+      dbPort: 5432
+      dbUsername: postgres
+      dbPassword: postgres123
+      dbName: inteli-api
+      dscpApiHost: tierone-api.tierone-subs
+      dscpApiPort: 80
+
+    image:
+      repository: ghcr.io/inteli-poc/dscp-chain-watcher
+      pullPolicy: IfNotPresent
+      tag: 'v1.0.4750d84'
+      pullSecrets:


### PR DESCRIPTION
Signed-off-by: TonyRowntree <33454202+TonyRowntree@users.noreply.github.com>

**Changelog**
- syncing chain watcher release from uat network to dev network

 


