### PR TITLE
[substrate] add id-service addr and port to dscp-chain-watcher

### DIFF
--- a/examples/dscp-app/charts/dscp-chain-watcher/Chart.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/Chart.yaml
@@ -6,7 +6,7 @@
 
 apiVersion: v2
 name: dscp-chain-watcher
-appVersion: '1.0.0'
+appVersion: '1.1.0'
 description: A Helm chart for dscp-chain-watcher
-version: '1.0.0'
+version: '1.1.0'
 type: application

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/configmap.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/configmap.yaml
@@ -14,3 +14,5 @@ data:
   dbHost: {{ .Values.config.dbHost }}
   dbPort: {{ .Values.config.dbPort | quote }}
   dbName: {{ .Values.config.dbName }}
+  idServiceHost: {{ .Values.config.idServiceHost }}
+  idServiceHost: {{ .Values.config.idServicePort | quote }}

--- a/examples/dscp-app/charts/dscp-chain-watcher/templates/cronjob.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/templates/cronjob.yaml
@@ -63,3 +63,13 @@ spec:
                   secretKeyRef:
                     name: {{ include "chain-watcher.fullname" . }}-secret
                     key: dbPassword
+              - name: IDENTITY_SERVICE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-secret
+                    key: idServiceHost
+              - name: IDENTITY_SERVICE_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ include "chain-watcher.fullname" . }}-secret
+                    key: idServicePort

--- a/examples/dscp-app/charts/dscp-chain-watcher/values.yaml
+++ b/examples/dscp-app/charts/dscp-chain-watcher/values.yaml
@@ -8,6 +8,8 @@ config:
   dbName: 
   dscpApiHost:
   dscpApiPort: 
+  idServiceHost:
+  idServicePort:
 
 image:
   repository: ghcr.io/inteli-poc/dscp-chain-watcher

--- a/examples/dscp-app/configuration/roles/helm_component/templates/dscp-chain-watcher.tpl
+++ b/examples/dscp-app/configuration/roles/helm_component/templates/dscp-chain-watcher.tpl
@@ -26,6 +26,8 @@ spec:
       dbName: {{ peer.inteli_api.db_name }}
       dscpApiHost: {{ dscp_api_addr }}.{{ component_ns }}
       dscpApiPort: {{ peer.api.port }}
+      idServiceHost: {{ peer.name }}-id-service.{{ component_ns }}
+      idServicePort: {{ peer.id_service.port }}
       
     image:
       repository: ghcr.io/inteli-poc/dscp-chain-watcher # {"$imagepolicy": "flux-{{ network.env.type }}:dscp-chain-watcher:name"}


### PR DESCRIPTION
**Changelog**
- Added id-service addr and port to the chain-watcher chart and template
- bumped chain-watcher version to 1.1.0

 

 

**Linked issue**
#INFRA-228
